### PR TITLE
Add manual game addition route

### DIFF
--- a/app.py
+++ b/app.py
@@ -78,6 +78,49 @@ def game_list():
 
     return render_template(template, user_games=user_games)
 
+
+@app.route("/games/add", methods=["GET", "POST"])
+@login_required
+def add_game():
+    form = AddGameForm()
+    if form.validate_on_submit():
+        cover_filename = None
+        if form.cover.data:
+            cover_file = form.cover.data
+            if allowed_file(cover_file.filename):
+                filename = secure_filename(cover_file.filename)
+                os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
+                cover_path = os.path.join(app.config['UPLOAD_FOLDER'], filename)
+                cover_file.save(cover_path)
+                cover_filename = filename
+            else:
+                flash("Недозволений формат файлу", "danger")
+                return render_template("games/add.html", form=form)
+
+        game = Game(
+            title=form.title.data,
+            release_year=form.release_year.data,
+            platform=form.platform.data,
+            cover=cover_filename,
+        )
+        db.session.add(game)
+        db.session.commit()
+
+        user_game = UserGame(
+            user_id=current_user.id,
+            game_id=game.id,
+            hours_played=form.hours_played.data or 0,
+            rating=form.rating.data,
+            imported_from="manual",
+        )
+        db.session.add(user_game)
+        db.session.commit()
+
+        flash("Гра додана до вашої бібліотеки!", "success")
+        return redirect(url_for('game_list'))
+
+    return render_template("games/add.html", form=form)
+
 @app.route("/games/add/<int:game_id>", methods=["POST"])
 @login_required
 def add_game_to_library(game_id):

--- a/templates/base.html
+++ b/templates/base.html
@@ -18,7 +18,7 @@
             <ul class="navbar-nav me-auto">
                 {% if current_user.is_authenticated %}
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('game_list') }}">Моя бібліотека</a></li>
-                    <li class="nav-item"><a class="nav-link" href="{{ url_for('add_game_to_library', game_id=0) }}">Додати гру</a></li>
+                    <li class="nav-item"><a class="nav-link" href="{{ url_for('add_game') }}">Додати гру</a></li>
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('import_games') }}">Імпорт</a></li>
                 {% endif %}
             </ul>


### PR DESCRIPTION
## Summary
- implement `/games/add` endpoint to allow manually creating games and associating them with the current user
- update navigation to link to the new manual addition page

## Testing
- `python -m py_compile $(git ls-files "*.py")`


------
https://chatgpt.com/codex/tasks/task_e_689b2380a0688320ae37d8d778be63bd